### PR TITLE
fix: deployment after mainnet launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,21 +26,25 @@ Import `Deployer.sol` into your deployment script and use as follows:
 import "lib/foundry-zksync-era/script/Deployer.sol";
 
 ...
+// Diamond proxy addresses, last updated 24.03.2023
+address DIAMOND_PROXY_MAINNET = 0x1908e2BF4a88F91E4eF0DC72f02b8Ea36BEa2319;
+address DIAMOND_PROXY_GOERLI = 0x32400084C286CF3E17e7B677ea9583e60a000324;
 
 // Provide zkSync compiler version and address of the diamond proxy on L1
-Deployer deployer = new Deployer("1.3.4", address(0x1908e2BF4a88F91E4eF0DC72f02b8Ea36BEa2319));
+Deployer deployer = new Deployer("1.3.7", DIAMOND_PROXY_MAINNET);
 
-// Provide path to contract, input params, salt & whether it should be broadcasted
+// Provide path to contract, input params, salt & whether it should broadcast
 // Returns deployment address on L2
 deployer.deployFromL1("src/Counter.sol", new bytes(0), bytes32(uint256(1337)), true);
 ```
 
-> Note: The Diamond Proxy address is the address of the L1 contract that handles all interactions with the zkSync network. At the time of writing, the diamond proxy for goerli was used in the example however this can change after regenesis & other network upgrades. This address will always be the same as the bridge and can be found by attempting to bridge assets at https://portal.zksync.io/bridge
+> Note: The Diamond Proxy address is the address of the L1 contract that handles all interactions with the zkSync network. This address will always be the same as the bridge and can be found by attempting to bridge assets at https://portal.zksync.io/bridge
 
-Ensure your private key is in your env:
+Ensure the private key and mainnet rpc values are set in your env:
 
 ```sh
 PRIVATE_KEY=""
+RPC_MAINNET=""
 ```
 
 Enable read/write permissions in your `foundry.toml`:
@@ -52,10 +56,10 @@ fs_permissions = [{ access = "read-write", path = "./"}]
 Deploy your contracts using the script you created:
 
 ```sh
-forge script scripts/Script.s.sol --ffi --broadcast --rpc-url L1_RPC_URL
+forge script script/Script.s.sol --ffi --broadcast --rpc-url L1_RPC_URL
 ```
 
-The transaction hash of the deployment on L2 will be returned by the broadcast. It is dependant on the block timestamp so it can not be accurately derrived within the script (before execution).
+The contract address is returned from the `deployFromL1()` function. The transaction hash of the deployment on L2 will be returned in the execution of the transaction. It is dependant on the block timestamp so it can not be accurately derrived within the script.
 
 > Note: It's also recommended to add `lib/zksolc*` to your project's `.gitignore`
 

--- a/script/Constants.sol
+++ b/script/Constants.sol
@@ -5,4 +5,8 @@ pragma solidity >=0.8.13;
 uint256 constant L2_TX_MAX_GAS_LIMIT = 2097152;
 uint256 constant DEFAULT_L2_GAS_PRICE_PER_PUBDATA = 800;
 
+// Add buffer to base fee since it can change before tx is executed
+// In percent form (10%)
+uint256 constant L2_BASE_FEE_BUFFER = 10;
+
 string constant ZKSOLC_BIN_REPO = "https://github.com/matter-labs/zksolc-bin";

--- a/script/Counter.s.sol
+++ b/script/Counter.s.sol
@@ -5,8 +5,10 @@ import "forge-std/Script.sol";
 import "./Deployer.sol";
 
 contract CounterScript is Script {
+    address DIAMOND_PROXY_GOERLI = 0x1908e2BF4a88F91E4eF0DC72f02b8Ea36BEa2319;
+
     function run() public {
-        Deployer deployer = new Deployer("1.3.4", address(0x1908e2BF4a88F91E4eF0DC72f02b8Ea36BEa2319));
-        deployer.deployFromL1("src/Counter.sol", new bytes(0), bytes32(uint256(1337)), true);
+        Deployer deployer = new Deployer("1.3.7", DIAMOND_PROXY_GOERLI);
+        address deployment = deployer.deployFromL1("src/Counter.sol", new bytes(0), bytes32(uint256(1234)), true);
     }
 }


### PR DESCRIPTION
## Overview
zkSync Era added the requirement to set the value of the transaction to include the fee of the transaction on L2. To accompany this, I added a call to get the baseCost and hardcoded a buffer of 10% to accompany fluctuating gas prices.

fixes #6 